### PR TITLE
replaced CGWindowListCreateImage

### DIFF
--- a/assets/code/WindowNavigator/WindowNavigator.swift
+++ b/assets/code/WindowNavigator/WindowNavigator.swift
@@ -11,6 +11,7 @@
 
 import Foundation
 import ApplicationServices
+import AppKit
 
 // MARK: - WindowNavigator
 struct WindowNavigator {
@@ -293,7 +294,15 @@ struct WindowWrapper: CustomDebugStringConvertible {
 	
 	/// If we succeed in creating a composited image representation of the window, then it is an actual window visible somewhere on some workspace.
 	var isValidWindow: Bool {
-		CGWindowListCreateImage(self.windowBounds, CGWindowListOption.optionIncludingWindow, UInt32(windowNumber), CGWindowImageOption.onlyShadows) != nil
+		// Prüfe grundlegende Fenstereigenschaften
+		guard windowAlpha > 0,                    // Fenster ist sichtbar
+			  windowBounds.size.width > 0,        // Fenster hat eine Breite
+			  windowBounds.size.height > 0,       // Fenster hat eine Höhe
+			  windowLayer == 0                    // Ist ein normales Fenster
+		else {
+			return false
+		}
+		return true
 	}
 	
 	var debugDescription: String {


### PR DESCRIPTION
Fix: Remove deprecated CGWindowListCreateImage dependency

Replace window validation using CGWindowListCreateImage with basic window property checks to ensure compatibility with macOS 15+. The new validation checks:

- Window alpha > 0 (visibility)
- Window width > 0
- Window height > 0
- Window layer = 0 (normal window)

This maintains core functionality while removing the deprecated API dependency.